### PR TITLE
Add optional label to show before the controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ collapsed: false or true
 //The position of the control (one of the map corners).
 position: 'topleft' or 'topright' or 'bottomleft' or 'bottomright'
 
+//Optional label to present before the controls (e.g. "Layers Opacity")
+label: string or null
+
 ```
 
 <br>

--- a/src/L.Control.Opacity.js
+++ b/src/L.Control.Opacity.js
@@ -1,7 +1,8 @@
 L.Control.Opacity = L.Control.extend({
 	options: {
 		collapsed: false,
-		position: 'topright'
+		position: 'topright',
+		label: null
 	},
 	initialize: function (overlays, options) {
 		L.Util.setOptions(this, options);
@@ -41,6 +42,11 @@ L.Control.Opacity = L.Control.extend({
 		container.setAttribute('aria-haspopup', true);
 		L.DomEvent.disableClickPropagation(container);
 		L.DomEvent.disableScrollPropagation(container);
+		if(this.options.label){
+			var labelSpan = L.DomUtil.create('span', className + "-label");
+			labelSpan.innerHTML = this.options.label;
+			container.appendChild(labelSpan);
+		}
 		var form = this._form = L.DomUtil.create('form', className + '-list');
 		if (collapsed) {
 			this._map.on('click', this.collapse, this);


### PR DESCRIPTION
Hi, with this pull request I want to add a configurable label to be presented before the layer opacity controls. In this way, if needed, a panel title like "Layer Opacity" can be added to further clarify the aim of the control.

Hope you like the idea