### PR TITLE
Update L.Control.Opacity.js

### DIFF
--- a/src/L.Control.Opacity.js
+++ b/src/L.Control.Opacity.js
@@ -117,7 +117,7 @@ L.Control.Opacity = L.Control.extend({
 			input.className = 'leaflet-control-layers-range';
             input.min = 0;
             input.max = 100;
-            input.value = 100;
+            input.value = obj.layer.options.opacity*100;
 		} else {
 			input = this._createRadioElement('leaflet-base-layers', checked);
 		}


### PR DESCRIPTION
This change to the default input.value will store previous opacity values if a layer is removed and re-added, which at least for my use is the preferred way of doing it.