### PR TITLE
add L.Control.Opacity.d.ts

### DIFF
--- a/dist/L.Control.Opacity.d.ts
+++ b/dist/L.Control.Opacity.d.ts
@@ -1,0 +1,18 @@
+import * as Leaflet from "leaflet";
+
+declare module "leaflet" {
+	interface OpacityOptions extends Leaflet.ControlOptions {
+		collapsed?: boolean
+		label?: string | null
+	}
+	namespace Control {
+		class Opacity extends Leaflet.Control {
+			constructor(
+				options?: OpacityOptions
+			)
+		}
+	}
+	namespace control {
+		function opacity(overlays: { [key: string]: L.Layer }, options: OpacityOptions): L.Control.Opacity
+	}
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.0",
   "description": "Leaflet.Control.Opacity is a Leaflet plugin that makes multiple tile layers transparent. (Leaflet v1.x.x)",
   "main": "dist/L.Control.Opacity.js",
+  "types": "dist/L.Control.Opacity.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dayjournal/Leaflet.Control.Opacity.git"


### PR DESCRIPTION
Hi, thank you very much for your very useful plugin!

I'm trying to use leaflet.control.opacity on a React+TypeScript project.
But it seems that there is no type definition file.
So I've written `L.Control.Opacity.d.ts` myself.
It's going well at least on my environment.
I'd like you to merge this PR if you don't mind.

Thank you.
